### PR TITLE
[Fix] Commenting type declarations breaks indentation syntax

### DIFF
--- a/src/strip_hints/strip_hints_main.py
+++ b/src/strip_hints/strip_hints_main.py
@@ -233,9 +233,9 @@ class HintStripper(object):
                     if t.type == tokenize.NL:
                         if not first_non_nl_token:
                             continue # Preceding comments are in token list; don't double the '#'.
-                        t.string = "\n#"
+                        t.string = "\npass #" # add pass to make the indentation valid
                     if not first_non_nl_token:
-                        t.string = "#" + t.string # was t.string[1:]
+                        t.string = "pass #" + t.string # was t.string[1:]
                         first_non_nl_token = True
                 return
 


### PR DESCRIPTION
Adds `pass` before making the line a comment, so code like:
```py
from typing import Protocol
class Style(Protocol):
    color: str
    effect: str
```
which would previously be invalid syntax when converted to:
```py
from typing import Protocol
class Style(Protocol):
    #color: str
    #effect: str
```
is now converted to
```py
from typing import Protocol
class Style(Protocol):
    pass #color: str
    pass #effect: str
```
and remains valid python code
